### PR TITLE
Use [[ to subset, and only if varCol has NA

### DIFF
--- a/CodeExamples/c06_Memorization_methods/00074_example_6.4_of_section_6.2.1.R
+++ b/CodeExamples/c06_Memorization_methods/00074_example_6.4_of_section_6.2.1.R
@@ -5,7 +5,7 @@
 mkPredC <- function(outCol,varCol,appCol) { 	# Note: 1 
    pPos <- sum(outCol==pos)/length(outCol) 	# Note: 2 
    naTab <- table(as.factor(outCol[is.na(varCol)]))
-   pPosWna <- (naTab/sum(naTab))[pos] 	# Note: 3 
+   pPosWna <- if (any(is.na(varCol))) (naTab / sum(naTab))[[pos]] else NULL 	# Note: 3 
    vTab <- table(as.factor(outCol),varCol)
    pPosWv <- (vTab[as.character(pos),]+1.0e-3*pPos)/(colSums(vTab)+1.0e-3) 	# Note: 4 
    pred <- pPosWv[appCol] 	# Note: 5 


### PR DESCRIPTION
Using `[` to subset won't return an element, but a list. Then, the list can't be assigned to `pred[is.na...]`. This fix uses `[[` to subset.

Moreover `[[` will fail is there are no `NA`s in the `varCol`. So, we check if there are `NA`s first.