### PR TITLE
Add v to selVars instead of pi

### DIFF
--- a/CodeExamples/c06_Memorization_methods/00081_example_6.11_of_section_6.3.1.R
+++ b/CodeExamples/c06_Memorization_methods/00081_example_6.11_of_section_6.3.1.R
@@ -40,7 +40,7 @@ for(v in catVars) {  	# Note: 2
   if(liCheck>minStep) {
      print(sprintf("%s, calibrationScore: %g",
         pi,liCheck))
-     selVars <- c(selVars,pi)
+     selVars <- c(selVars,v)
   }
 }
 
@@ -51,7 +51,7 @@ for(v in numericVars) { 	# Note: 3
   if(liCheck>=minStep) {
      print(sprintf("%s, calibrationScore: %g",
         pi,liCheck))
-     selVars <- c(selVars,pi)
+     selVars <- c(selVars,v)
   }
 }
 


### PR DESCRIPTION
Shouldn't `v` be added to `selVars` instead of `pi`, especially if `selVars` are later used in `rpart` (Listing 6.16) to build a decision tree?